### PR TITLE
Fix autolinks followed by ')'

### DIFF
--- a/autolink_references/main.py
+++ b/autolink_references/main.py
@@ -7,16 +7,16 @@ def replace_autolink_references(markdown, reference_prefix, target_url):
     if "<num>" not in reference_prefix:
         reference_prefix = reference_prefix + "<num>"
 
-    find_regex = reference_prefix.replace("<num>", "([0-9]+)")
-    find_regex = "[\\[]?" + find_regex + "[\\]]?(\\(?.*\\)?)"
+    find_regex = reference_prefix.replace("<num>", "(?P<num>[0-9]+)")
+    find_regex = "(?P<b>\\[)?(?P<text>" + find_regex + ")(?(b)\\])(?(b)(?:\\((?P<url>.*?)\\))?)"
 
     def ref_replace(matchobj):
-        if matchobj.group(2) == "(":
+        if matchobj.group('url'):
             return matchobj.group(0)
 
         return "[{}]({})".format(
-            reference_prefix.replace('<num>', matchobj.group(1)),
-            target_url.replace("<num>", matchobj.group(1))
+            reference_prefix.replace('<num>', matchobj.group('num')),
+            target_url.replace("<num>", matchobj.group('num'))
         )
 
     markdown = re.sub(find_regex,


### PR DESCRIPTION
An autolink followed by ')' did not work as expected, the regex swallowed the full line after it.

The reason was that '(' had a '?' modifier.