### PR TITLE
add 'look_for_alphanumeric_id' flag to enable parsing values that are not only digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,14 @@ plugins:
               target_url: https://linear.com/AF-<num>
             - reference_prefix: PROJ-
               target_url: https://jiracloud.com/PROJ-<num>
+            - reference_prefix: GIT@
+              target_url: https://github.com/<num>
+              look_for_alphanumeric_id: true
 ```
 
 - __reference_prefix__: This prefix appended by a number will generate a link any time it is found in a page.
 - __target_url__: The URL must contain `<num>` for the reference number.
+- __look_for_alphanumeric_id__: **(optional, default=false)** Allow values for `<num>` that are not only numeric but also alphanumeric including "-_/"
 
 ### An example
 

--- a/autolink_references/main.py
+++ b/autolink_references/main.py
@@ -3,11 +3,15 @@ from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
 
 
-def replace_autolink_references(markdown, reference_prefix, target_url):
+def replace_autolink_references(markdown, reference_prefix, target_url, look_for_alphanumeric_id=False):
     if "<num>" not in reference_prefix:
         reference_prefix = reference_prefix + "<num>"
 
-    find_regex = reference_prefix.replace("<num>", "(?P<num>[0-9]+)")
+    if look_for_alphanumeric_id:
+        find_regex = reference_prefix.replace("<num>", "(?P<num>[A-Za-z0-9-_/]+)")
+    else:
+        find_regex = reference_prefix.replace("<num>", "(?P<num>[0-9]+)")
+
     find_regex = (
         "(?P<b>\\[)?(?P<text>" + find_regex + ")(?(b)\\])(?(b)(?:\\((?P<url>.*?)\\))?)"
     )
@@ -42,6 +46,8 @@ class AutoLinkOption(config_options.OptionallyRequired):
                 )
             if "<num>" not in autolink["target_url"]:
                 raise config_options.ValidationError("Missing '<num>' in 'target_url'.")
+            if "look_for_alphanumeric_id" not in autolink:
+                autolink["look_for_alphanumeric_id"] = False
 
         return values
 
@@ -62,7 +68,7 @@ class AutolinkReference(BasePlugin):
         """
         for autolink in self.config["autolinks"]:
             markdown = replace_autolink_references(
-                markdown, autolink["reference_prefix"], autolink["target_url"]
+                markdown, autolink["reference_prefix"], autolink["target_url"], autolink["look_for_alphanumeric_id"]
             )
 
         return markdown

--- a/tests/test_alphanumeric_parser.py
+++ b/tests/test_alphanumeric_parser.py
@@ -1,0 +1,22 @@
+import pytest
+
+from autolink_references.main import replace_autolink_references as autolink
+
+markdown_samples = [
+    ("#A", "[#A](http://example/A)"),
+    ("#A-1", "[#A-1](http://example/A-1)"),
+    ("hello #B/_-A1", "hello [#B/_-A1](http://example/B/_-A1)"),
+    ("(#2)", "([#2](http://example/2))"),
+    ("x (#nn02)", "x ([#nn02](http://example/nn02))"),
+    ("x (#2) y", "x ([#2](http://example/2)) y"),
+    ("(#AA___//2)", "([#AA___//2](http://example/AA___//2))"),
+    ("#A-1?????test", "[#A-1](http://example/A-1)?????test"),
+]
+
+
+@pytest.mark.parametrize("test_input,expected", markdown_samples)
+def test_alphanumeric_parser(test_input, expected):
+    ref_prefix = "#<num>"
+    target_url = "http://example/<num>"
+
+    assert autolink(test_input, ref_prefix, target_url, True) == expected

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -17,4 +17,4 @@ def test_parser(test_input, expected):
     ref_prefix = "#<num>"
     target_url = "http://gh/<num>"
 
-    assert autolink(test_input, ref_prefix, target_url) == expected
+    assert autolink(test_input, ref_prefix, target_url, False) == expected


### PR DESCRIPTION
This PR adds the settings flag "look_for_alphanumeric_id" which can be set to true to allow for parsing non-numeric IDs.
It is false by default, so nothing changes with existing configs. I've also created testcases for this feature.

Example:
```yaml
- reference_prefix: GIT@
  target_url: 'https://github.com/<num>'
  look_for_alphanumeric_id: true
```
transforms:
`GIT@k4ds3/plavatar` into `https://github.com/k4ds3/plavatar`

Feel free to merge this if you find it useful too.