### PR TITLE
Allow extended set for <num> and ignore ref style links, already linked items, and attr_list cases with '#' before the ref

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "python.testing.pytestArgs": [
+        "tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
+}

--- a/autolink_references/main.py
+++ b/autolink_references/main.py
@@ -3,7 +3,19 @@ from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
 
 
-def replace_autolink_references(markdown, reference_prefix, target_url):
+def replace_autolink_references(markdown, ref_prefix, target_url):
+    if "<num>" not in ref_prefix:
+        ref_prefix = ref_prefix + "<num>"
+    find_regex = re.compile(
+        r"(?<![#\[/])" + ref_prefix.replace(r"<num>", r"(?P<num>[-\w]+)")
+    )
+    linked_ref = rf"[{ref_prefix}](" + target_url + r")"
+    replace_text = linked_ref.replace(r"<num>", r"\g<num>")
+    markdown = re.sub(find_regex, replace_text, markdown, re.IGNORECASE)
+    return markdown
+
+
+def areplace_autolink_references(markdown, reference_prefix, target_url):
     if "<num>" not in reference_prefix:
         reference_prefix = reference_prefix + "<num>"
 

--- a/autolink_references/main.py
+++ b/autolink_references/main.py
@@ -15,29 +15,6 @@ def replace_autolink_references(markdown, ref_prefix, target_url):
     return markdown
 
 
-def areplace_autolink_references(markdown, reference_prefix, target_url):
-    if "<num>" not in reference_prefix:
-        reference_prefix = reference_prefix + "<num>"
-
-    find_regex = reference_prefix.replace("<num>", "(?P<num>[0-9]+)")
-    find_regex = (
-        "(?P<b>\\[)?(?P<text>" + find_regex + ")(?(b)\\])(?(b)(?:\\((?P<url>.*?)\\))?)"
-    )
-
-    def ref_replace(matchobj):
-        if matchobj.group("url"):
-            return matchobj.group(0)
-
-        return "[{}]({})".format(
-            reference_prefix.replace("<num>", matchobj.group("num")),
-            target_url.replace("<num>", matchobj.group("num")),
-        )
-
-    markdown = re.sub(find_regex, ref_replace, markdown, flags=re.IGNORECASE)
-
-    return markdown
-
-
 class AutoLinkOption(config_options.OptionallyRequired):
     def run_validation(self, values):
         if not isinstance(values, list):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -45,6 +45,7 @@ ignore_already_linked = [
     ),
 ]
 
+# This test cases address #4. Reference style links should be ignored.
 ignore_ref_links = [
     ("TAG-<num>", "http://gh/<num>", "[TAG-456]", "[TAG-456]"),
     ("TAG-<num>", "http://gh/<num>", "[TAG-456][test456]", "[TAG-456][test456]"),
@@ -66,6 +67,7 @@ def test_parser(ref_prefix, target_url, test_input, expected):
     assert autolink(test_input, ref_prefix, target_url) == expected
 
 
+# This test address #5. It currently only checks for '#' before the link
 def test_with_attr_list():
     text = "## Feature 1 { #F-001 .class-feature }"
     ref_prefix = "F-<num>"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -2,19 +2,72 @@ import pytest
 
 from autolink_references.main import replace_autolink_references as autolink
 
-markdown_samples = [
-    ("#1", "[#1](http://gh/1)"),
-    ("hello #1", "hello [#1](http://gh/1)"),
-    ("(#2)", "([#2](http://gh/2))"),
-    ("x (#2)", "x ([#2](http://gh/2))"),
-    ("x (#2) y", "x ([#2](http://gh/2)) y"),
-    ("(#2)", "([#2](http://gh/2))"),
+simple_replace = [
+    ("TAG-<num>", "http://gh/<num>", "TAG-123", "[TAG-123](http://gh/123)"),
+    ("TAG-<num>", "http://gh/<num>", "x TAG-123", "x [TAG-123](http://gh/123)"),
+    ("TAG-<num>", "http://gh/<num>", "TAG-123 x", "[TAG-123](http://gh/123) x"),
+    ("TAG-<num>", "http://gh/<num>", "x TAG-123 y", "x [TAG-123](http://gh/123) y"),
+    ("TAG-<num>", "http://gh/<num>", "x TAG-123 y", "x [TAG-123](http://gh/123) y"),
+    ("TAG-<num>", "http://gh/TAG-<num>", "(TAG-123)", "([TAG-123](http://gh/TAG-123))"),
+    ("TAG-", "http://forgot-num/<num>", "TAG-543", "[TAG-543](http://forgot-num/543)"),
+    (
+        "TAG-<num>",
+        "http://gh/TAG-<num>",
+        "(TAG-12_3-4)",
+        "([TAG-12_3-4](http://gh/TAG-12_3-4))",
+    ),
+    (
+        "TAG-<num>",
+        "http://gh/<num>",
+        "x TAG-123 y TAG-456 z",
+        "x [TAG-123](http://gh/123) y [TAG-456](http://gh/456) z",
+    ),
+    (
+        "TAG-<num>",
+        "http://gh/TAG-<num>",
+        "TAG-Ab123dD",
+        "[TAG-Ab123dD](http://gh/TAG-Ab123dD)",
+    ),
+]
+
+ignore_already_linked = [
+    (
+        "TAG-<num>",
+        "http://gh/<num>",
+        "[TAG-789](http://gh/789)",
+        "[TAG-789](http://gh/789)",
+    ),
+    (
+        "TAG-<num>",
+        "http://gh/TAG-<num>",
+        "[TAG-789](http://gh/TAG-789)",
+        "[TAG-789](http://gh/TAG-789)",
+    ),
+]
+
+ignore_ref_links = [
+    ("TAG-<num>", "http://gh/<num>", "[TAG-456]", "[TAG-456]"),
+    ("TAG-<num>", "http://gh/<num>", "[TAG-456][test456]", "[TAG-456][test456]"),
+    ("TAG-<num>", "http://gh/<num>", "[TAG-456] [tag456]", "[TAG-456] [tag456]"),
+    (
+        "TAG-<num>",
+        "http://gh/TAG-<num>",
+        "[tag456]: http://gh/TAG-456",
+        "[tag456]: http://gh/TAG-456",
+    ),
 ]
 
 
-@pytest.mark.parametrize("test_input,expected", markdown_samples)
-def test_parser(test_input, expected):
-    ref_prefix = "#<num>"
-    target_url = "http://gh/<num>"
-
+@pytest.mark.parametrize(
+    "ref_prefix, target_url, test_input, expected",
+    simple_replace + ignore_already_linked + ignore_ref_links,
+)
+def test_parser(ref_prefix, target_url, test_input, expected):
     assert autolink(test_input, ref_prefix, target_url) == expected
+
+
+def test_with_attr_list():
+    text = "## Feature 1 { #F-001 .class-feature }"
+    ref_prefix = "F-<num>"
+    target_url = "http://gh/<num>"
+    assert autolink(text, ref_prefix, target_url) == text


### PR DESCRIPTION
The `<num>` part of the reference can now match any letter, digit, underscore, or hyphen.

For example:
```
TAG-xy12_3-z  ==> [TAG-xy12_3-z](http://gh/xy12_3-z)
```

Any reference preceded by a `#`, `[`, or `/` character is now ignored. This allows ignoring of already linked references, reference style links, and basic use of the pymarkdown attr_list extension. The following are now ignored in the markdown text.

```
[TAG-123](http://gh/TAG-123)
[TAG-456][tag456]
[TAG-456] [tag456]
## Feature 1 { #F-001 .class-feature }

[tag456]: http://gh/TAG-456
```

Tests were added for each of these items. Tests and build pass.