### PR TITLE
Fix regex count bug

### DIFF
--- a/src/autolink_references/main.py
+++ b/src/autolink_references/main.py
@@ -7,11 +7,12 @@ def replace_autolink_references(markdown, ref_prefix, target_url):
     if "<num>" not in ref_prefix:
         ref_prefix = ref_prefix + "<num>"
     find_regex = re.compile(
-        r"(?<![#\[/])" + ref_prefix.replace(r"<num>", r"(?P<num>[-\w]+)")
+        r"(?<![#\[/])" + ref_prefix.replace(r"<num>", r"(?P<num>[-\w]+)"),
+        re.IGNORECASE,
     )
     linked_ref = rf"[{ref_prefix}](" + target_url + r")"
     replace_text = linked_ref.replace(r"<num>", r"\g<num>")
-    markdown = re.sub(find_regex, replace_text, markdown, re.IGNORECASE)
+    markdown = re.sub(find_regex, replace_text, markdown)
     return markdown
 
 


### PR DESCRIPTION
There was a bug limiting the plugin to replace as most 2 issue references on a page.

The fourth param of re.sub is count, not flags. `re.IGNORECASE` evaluates to 2 so therefore the max number of replacements was 2. I have moved it to the `re.compile` line.